### PR TITLE
Raw Block Volume

### DIFF
--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -39,7 +39,10 @@ func devFromVolumeId(id string, diskInterface ovirtsdk.DiskInterface) (string, e
 func (n *NodeService) NodeStageVolume(_ context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	klog.Infof("Staging volume %s with %+v", req.VolumeId, req)
 	device, err := getDeviceByAttachmentId(req.VolumeId, n.nodeId, n.ovirtClient.connection)
-
+	if err == nil && req.GetVolumeCapability().GetBlock() != nil {
+		//No staging necessary for block device
+		return &csi.NodeStageVolumeResponse{}, nil
+	}
 	// is there a filesystem on this device?
 	filesystem, err := getDeviceInfo(device)
 	if err != nil {
@@ -66,19 +69,36 @@ func (n *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	device, err := getDeviceByAttachmentId(req.VolumeId, n.nodeId, n.ovirtClient.connection)
 
 	targetPath := req.GetTargetPath()
-	err = os.MkdirAll(targetPath, 0750)
-	if err != nil {
-		return nil, errors.New(err.Error())
-	}
 
-	fsType := req.VolumeCapability.GetMount().FsType
-	klog.Infof("Mounting devicePath %s, on targetPath: %s with FS type: %s",
-		device, targetPath, fsType)
-	mounter := mount.New("")
-	err = mounter.Mount(device, targetPath, fsType, []string{})
-	if err != nil {
-		klog.Errorf("Failed mounting %v", err)
-		return nil, err
+	if req.GetVolumeCapability().GetMount() != nil {
+		err = os.MkdirAll(targetPath, 0750)
+		if err != nil {
+			return nil, errors.New(err.Error())
+		}
+		fsType := req.VolumeCapability.GetMount().FsType
+		klog.Infof("Mounting devicePath %s, on targetPath: %s with FS type: %s",
+			device, targetPath, fsType)
+		mounter := mount.New("")
+		err = mounter.Mount(device, targetPath, fsType, []string{})
+		if err != nil {
+			klog.Errorf("Failed mounting %v", err)
+			return nil, err
+		}
+	} else {
+
+		file, err := os.Create(targetPath)
+		if err != nil {
+			return nil, errors.New(err.Error())
+		}
+		file.Close()
+		klog.Infof("Mounting devicePath %s, on targetPath: %s bind mount",
+			device, targetPath)
+		mounter := mount.New("")
+		err = mounter.Mount(device, targetPath, "", []string{"bind"})
+		if err != nil {
+			klog.Errorf("Failed mounting %v", err)
+			return nil, err
+		}
 	}
 
 	return &csi.NodePublishVolumeResponse{}, nil


### PR DESCRIPTION
This adds support for the raw block volume feature (https://kubernetes-csi.github.io/docs/raw-block.html). It's accomplished by not creating a file system on the device and bind mounting it to the target path instead of a regular mount.