### PR TITLE
use blkid instead of lsblk to detect FS

### DIFF
--- a/deploy/csi-driver/030-node.yaml
+++ b/deploy/csi-driver/030-node.yaml
@@ -109,6 +109,8 @@ spec:
               mountPropagation: Bidirectional
             - name: host-dev
               mountPath: /dev
+            - name: udev
+              mountPath: /run/udev
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: Bidirectional
@@ -132,6 +134,9 @@ spec:
         - name: host-dev
           hostPath:
             path: /dev
+        - name: udev
+          hostPath:
+            path: /run/udev
         - name: config
           emptyDir: {}
         - name: mountpoint-dir

--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -162,22 +162,22 @@ func getDeviceInfo(device string) (string, error) {
 		return "", errors.New(err.Error())
 	}
 
-	klog.Info("blkid -o value -s TYPE ", devicePath)
-	cmd := exec.Command("blkid", "-o", "value", "-s", "TYPE", devicePath)
+	klog.Info("lsblk -nro FSTYPE ", devicePath)
+	cmd := exec.Command("lsblk", "-nro", "FSTYPE", devicePath)
 	out, err := cmd.Output()
 	exitError, incompleteCmd := err.(*exec.ExitError)
 	if err != nil && incompleteCmd {
 		if exitError.ExitCode() == 2 {
 			return "", nil
 		}
-		klog.Errorf("Couldn't run blkid on %s", device)
-		return "", errors.New(err.Error() + "blkid failed with " + string(exitError.Stderr))
+		klog.Errorf("Couldn't run lsblk on %s", device)
+		return "", errors.New(err.Error() + "lsblk failed with " + string(exitError.Stderr))
 	}
 
 	reader := bufio.NewReader(bytes.NewReader(out))
 	line, _, err := reader.ReadLine()
 	if err != nil {
-		klog.Errorf("Error occured while trying to read blkid output")
+		klog.Errorf("Error occured while trying to read lsblk output")
 		return "", err
 	}
 	return string(line), nil


### PR DESCRIPTION
lsblk always returns the FSTYPE field empty inside the container. This patch uses blkid to detect whether we have a filesystem on the device to avoid unnecessary creation (which also wipes the device).