### PR TITLE
return OK when disk attachment is not found

### DIFF
--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -162,8 +162,8 @@ func (c *ControllerService) ControllerUnpublishVolume(_ context.Context, req *cs
 
 	attachment, err := diskAttachmentByVmAndDisk(conn, req.NodeId, req.VolumeId)
 	if err != nil {
-		klog.Errorf("Failed to get disk attachment %s for VM %s", req.VolumeId, req.NodeId)
-		return nil, err
+		klog.Errorf("Failed to get disk attachment %s for VM %s, returning OK", req.VolumeId, req.NodeId)
+		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 	_, err = conn.SystemService().VmsService().VmService(req.NodeId).
 		DiskAttachmentsService().


### PR DESCRIPTION
According to the spec[1], ControllerUnpublishVolume should return OK if the volume is not attached. If we cannot find the disk attachment on the VM we can assume the disk is not attached and not return any errors.


[1] https://github.com/container-storage-interface/spec/blob/master/spec.md#controllerunpublishvolume