### PR TITLE
added missing error-handling

### DIFF
--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -46,7 +46,11 @@ func (n *NodeService) NodeStageVolume(_ context.Context, req *csi.NodeStageVolum
 	}
 
 	device, err := getDeviceByAttachmentId(req.VolumeId, n.nodeId, conn)
-
+	if err != nil {
+		klog.Errorf("Failed to fetch device by attachment-id for volume %s on node %s", req.VolumeId, n.nodeId)
+		return nil, err
+	}
+  
 	// is there a filesystem on this device?
 	filesystem, err := getDeviceInfo(device)
 	if err != nil {
@@ -80,7 +84,12 @@ func (n *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		klog.Errorf("Failed to get ovirt client connection")
 		return nil, err
 	}
+	
 	device, err := getDeviceByAttachmentId(req.VolumeId, n.nodeId, conn)
+	if err != nil {
+		klog.Errorf("Failed to fetch device by attachment-id for volume %s on node %s", req.VolumeId, n.nodeId)
+		return nil, err
+	}
 
 	targetPath := req.GetTargetPath()
 	err = os.MkdirAll(targetPath, 0750)


### PR DESCRIPTION
Added missing error-handling to `getDeviceByAttachmentId`. This helped us greatly identifying an issue with the driver (see #31).