### PR TITLE
Write a cafile using the ca_bundle content from ovirt-credentials

### DIFF
--- a/deploy/csi-driver/030-node.yaml
+++ b/deploy/csi-driver/030-node.yaml
@@ -35,15 +35,17 @@ spec:
                   name: ovirt-credentials
                   key: ovirt_password
             - name: OVIRT_CAFILE
-              valueFrom:
-                secretKeyRef:
-                  name: ovirt-credentials
-                  key: ovirt_cafile
+              value: /tmp/config/ovirt-engine-ca.pem
             - name: OVIRT_INSECURE
               valueFrom:
                 secretKeyRef:
                   name: ovirt-credentials
                   key: ovirt_insecure
+            - name: OVIRT_CA_BUNDLE
+                valueFrom:
+                  secretKeyRef:
+                    name: ovirt-credentials
+                    key: ovirt_ca_bundle
           image: busybox
           command:
             - /bin/sh
@@ -57,6 +59,7 @@ spec:
               ovirt_cafile: $OVIRT_CAFILE
               ovirt_insecure: $OVIRT_INSECURE
               EOF
+              echo "$OVIRT_CA_BUNDLE" > $OVIRT_CAFILE
           volumeMounts:
             - name: config
               mountPath: /tmp/config

--- a/deploy/csi-driver/040-controller.yaml
+++ b/deploy/csi-driver/040-controller.yaml
@@ -36,15 +36,17 @@ spec:
                   name: ovirt-credentials
                   key: ovirt_password
             - name: OVIRT_CAFILE
-              valueFrom:
-                secretKeyRef:
-                  name: ovirt-credentials
-                  key: ovirt_cafile
+              value: /tmp/config/ovirt-engine-ca.pem
             - name: OVIRT_INSECURE
               valueFrom:
                 secretKeyRef:
                   name: ovirt-credentials
                   key: ovirt_insecure
+            - name: OVIRT_CA_BUNDLE
+                valueFrom:
+                  secretKeyRef:
+                    name: ovirt-credentials
+                    key: ovirt_ca_bundle
           image: busybox
           command:
             - /bin/sh
@@ -58,6 +60,7 @@ spec:
               ovirt_cafile: $OVIRT_CAFILE
               ovirt_insecure: $OVIRT_INSECURE
               EOF
+              echo "$OVIRT_CA_BUNDLE" > $OVIRT_CAFILE
           volumeMounts:
             - name: config
               mountPath: /tmp/config


### PR DESCRIPTION
The fix here is for the deployment yamls for whoever does that manually. 
The more appropriate fix is to the operator that generates the deployment objects https://github.com/oVirt/csi-driver-operator/pull/11

